### PR TITLE
Don't use serialization for a Hash attribute

### DIFF
--- a/lib/shrine/plugins/rom.rb
+++ b/lib/shrine/plugins/rom.rb
@@ -45,6 +45,13 @@ class Shrine
           rom.retrieve_record { |entity| yield entity }
         end
 
+        # Returns true if the data attribute represents a JSON or JSONB column.
+        # Used by the _persistence plugin to determine whether serialization
+        # should be skipped.
+        def rom_hash_attribute?
+          record.public_send(attribute).is_a?(Hash)
+        end
+
         # Returns whether the record is a ROM entity. Used by the _persistence
         # plugin.
         def rom?

--- a/lib/shrine/plugins/rom.rb
+++ b/lib/shrine/plugins/rom.rb
@@ -49,7 +49,10 @@ class Shrine
         # Used by the _persistence plugin to determine whether serialization
         # should be skipped.
         def rom_hash_attribute?
-          record.public_send(attribute).is_a?(Hash)
+          return false unless repository
+
+          column = rom.column_type(attribute)
+          column && [:json, :jsonb].include?(column.to_sym)
         end
 
         # Returns whether the record is a ROM entity. Used by the _persistence
@@ -87,6 +90,12 @@ class Shrine
           else
             yield record_relation.one!
           end
+        end
+
+        def column_type(attribute)
+          # sends "json" or "jsonb" string for JSON or JSONB column.
+          # returns nil for String column
+          relation.schema[attribute].type.meta[:db_type]
         end
 
         private


### PR DESCRIPTION
This check is not only for performance optimization. Without this check, `column_data` (called by [column values](https://github.com/shrinerb/shrine-rom/blob/89ee2c2c8e996991ac7450c9384f498886e38ce5/lib/shrine/plugins/rom.rb#L39)) gets serialized and the value is stored as a string instead of a JSON in JSON/JSONB column.